### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/apply-argv.asd
+++ b/apply-argv.asd
@@ -8,9 +8,10 @@
   :serial t
   :depends-on (:alexandria)
   :components ((:file "package")
-               (:file "apply-argv")))
+               (:file "apply-argv"))
+  :in-order-to ((test-op (test-op #:apply-argv/tests))))
 
-(asdf:defsystem #:apply-argv-tests
+(asdf:defsystem #:apply-argv/tests
   :version "0.1"
   :author "Peter von Etter"
   :description "Test system of apply-argv."
@@ -18,9 +19,6 @@
   :serial t
   :depends-on (:fiveam
                :apply-argv)
-  :components ((:file "tests")))
-
-(defmethod asdf:perform ((op test-op)
-                         (c (eql (find-system :apply-argv))))
-  (require :apply-argv-tests)
-  (funcall (read-from-string "5AM:RUN!") :apply-argv))
+  :components ((:file "tests"))
+  :perform (test-op (op system)
+             (uiop:symbol-call :5am :run! :apply-argv)))


### PR DESCRIPTION
ASDF3 recommends a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
